### PR TITLE
Allow passing cuda library handles to the triangulator

### DIFF
--- a/triangulators/lexTriangulator.hpp
+++ b/triangulators/lexTriangulator.hpp
@@ -16,106 +16,55 @@
 
 class LexTriangulator : public Triangulator {
     public:
-        LexTriangulator(double* x, const int n, const int d) : Triangulator(x, n, d){
-#if DO_TIMING == 1
-            double start;
-            double elaps;
-            double start_full;
-            double elaps_full;
+#if USE_CUDA == 1
+        LexTriangulator(double* x, const int n, const int d, cublasLtHandle_t handle1, cusolverDnHandle_t handle2) : Triangulator(x, n, d){
+            ltHandle = handle1;
+            dnHandle = handle2;
 
-            start_full = cpuSeconds();
+            cudaMalloc(reinterpret_cast<void **>(&d_x), sizeof(double)*n*d);
+            cudaMemcpy(d_x, x, sizeof(double)*n*d, cudaMemcpyHostToDevice);
+        }
 #endif
+        LexTriangulator(double* x, const int n, const int d) : Triangulator(x, n, d){
 #if USE_CUDA == 1
             cublasStatus_t status;
             cusolverStatus_t sStatus;
-            // cudaError_t cudaStat; TODO Delete after verification
 
-            // Cublas Lt
-#if DO_TIMING == 1
-            start = cpuSeconds();
-#endif
             status = cublasLtCreate(&ltHandle);
-            if (status != CUBLAS_STATUS_SUCCESS) {
-                useCublas = false;
-            }
-#if DO_TIMING == 1
-            elaps = cpuSeconds() - start;
-            std::cout << "Initializing cublasLt handle took: " << elaps << " seconds\n";
-#endif
+            assert(status == CUBLAS_STATUS_SUCCESS);
 
-
-#if DO_TIMING == 1
-            start = cpuSeconds();
-#endif
-            // Cublas Handle
-            status = cublasCreate(&cblsHandle);
-
-#if DO_TIMING == 1
-            elaps = cpuSeconds() - start;
-            std::cout << "Initializing cublas handle took: " << elaps << " seconds\n";
-#endif
-
-#if DO_TIMING == 1
-            start = cpuSeconds();
-#endif
-            // cusolverDn
             sStatus = cusolverDnCreate(&dnHandle);
-            assert(CUSOLVER_STATUS_SUCCESS == sStatus);
+            assert(sStatus == CUSOLVER_STATUS_SUCCESS);
 
-            checkCudaStatus(cudaStreamCreateWithFlags(&stream, 
+            checkCudaStatus(cudaStreamCreateWithFlags(&stream,
                         cudaStreamNonBlocking), __LINE__);
 
             sStatus = cusolverDnSetStream(dnHandle, stream);
-            assert(CUSOLVER_STATUS_SUCCESS == sStatus);
-#if DO_TIMING == 1
-            elaps = cpuSeconds() - start;
-            std::cout << "Initializing cusolver handle took: " << elaps << " seconds\n";
-#endif
+            assert(sStatus == CUSOLVER_STATUS_SUCCESS);
 
-#if DO_TIMING == 1
-            start = cpuSeconds();
-#endif
+            freeHandles = true;
+
             cudaMalloc(reinterpret_cast<void **>(&d_x), sizeof(double)*n*d);
             cudaMemcpy(d_x, x, sizeof(double)*n*d, cudaMemcpyHostToDevice);
-#if DO_TIMING == 1
-            elaps = cpuSeconds() - start;
-            std::cout << "Initializing d_x took: " << elaps << " seconds\n";
-#endif
-#endif
-#if DO_TIMING == 1
-            elaps_full = cpuSeconds() - start_full;
-            std::cout << "Lex Triangulation Object Initialization took: " << elaps_full << " seconds\n";
 #endif
         }
         ~LexTriangulator() { 
 #if USE_CUDA == 1
-            // TODO Destroy cuSolverDn handle and the steam it is bound to.
-            cublasStatus_t status;
+            cudaFree(d_x);
 
-            status = cublasLtDestroy(ltHandle);
-            status = cublasDestroy(cblsHandle);
-
-            if (status != CUBLAS_STATUS_SUCCESS) {
-                // TODO print error and raise exception
-            }
-
-            if (dnHandle) {
+            if (freeHandles) {
+                cublasLtDestroy(ltHandle);
                 cusolverDnDestroy(dnHandle);
-            }
-            if (stream) {
                 cudaStreamDestroy(stream);
             }
-
-            cudaFree(d_x);
 #endif
             delete[] scriptyH;
         }
         void computeTri() override;
     protected:
 #if USE_CUDA == 1
-        bool useCublas {true};
+        bool freeHandles {false};
         cublasLtHandle_t ltHandle;
-        cublasHandle_t cblsHandle;
         cusolverDnHandle_t dnHandle;
         cudaStream_t stream;
         double *d_x;


### PR DESCRIPTION
Add an extra constructor for passing cublasLt and cusolverDn handles to the triangulator.  The main routine now uses this new constructor.